### PR TITLE
Scoring data is no longer separated into list based data type

### DIFF
--- a/scripts/batch_scoring.py
+++ b/scripts/batch_scoring.py
@@ -48,27 +48,25 @@ def run_single(output_dir: str, pilot_dir: str):
       "./libs/common-lang3.jar:./libs/opencsv-5.7.0.jar:./libs/weka.jar:./src",
       "scoring/ScoreRunner"
    ]
-   data_files: list[str] = glob(f"{pilot_dir}/*.csv")
-   flight_data_index: int = -1
+   data_files: list[str] = []
+   txt_file = glob(f"{pilot_dir}/*xplane.txt")  # check for xplane.txt file
 
+   if txt_file:   # xplane.txt file found, so txt_files is not empty
+      data_files += txt_file
+   else:          # no flight data found
+      print(f"No xplane.txt found in {pilot_dir}")
+      return
+   data_files += glob(f"{pilot_dir}/*.csv")
+
+   datarefs_index = -1
    for i, file in enumerate(data_files):
       if re.search(regex, file):
-         flight_data_index = i
+         datarefs_index = i
          break
 
-   # no datarefs file, find xplane.txt file
-   if flight_data_index == -1:
-      txt_file = glob(f"{pilot_dir}/*xplane.txt")  # check for xplane.txt file
-
-      if txt_file:   # xplane.txt file found, so txt_files is not empty
-         data_files += txt_file
-         flight_data_index = len(data_files) - 1
-      else:          # no flight data found
-         print(f"No flight data found in {pilot_dir}")
-         return
-   
-   # put flight data file in front of list
-   data_files[0], data_files[flight_data_index] = data_files[flight_data_index], data_files[0]
+   if datarefs_index != -1:
+      # put datarefs file second in list
+      data_files[1], data_files[datarefs_index] = data_files[datarefs_index], data_files[1]
    java_program += [output_dir] + data_files
    subprocess.run(java_program)
 

--- a/src/scoring/DataIndex.java
+++ b/src/scoring/DataIndex.java
@@ -1,0 +1,172 @@
+package scoring;
+
+public class DataIndex {
+   // the indexes for the X-Plane data we use for scoring and statistics
+   private int iSysTime = -1;
+   private int iAlt = -1;
+   private int iDme = -1;
+   private int iHdef = -1;
+   private int iVdef = -1;
+   private int iASpeed = -1;
+   private int iMTime = -1;
+   private int iGroll = -1;
+   private int iVspeed = -1;
+   private int iBank = -1;
+   private int iEng = -1;
+   private int iHead = -1;
+   private int iLongitude = -1;
+   private int iLatitude = -1;
+
+   /**
+    * Default constructor.
+    */
+   public DataIndex() {
+   };
+
+   /**
+    * Constructor.
+    * 
+    * @param iSysTime system time index
+    * @param iAlt     altitude index
+    * @param iDme     DME index
+    * @param iHdef    localizer deflection index
+    * @param iVdef    glideslope deflection index
+    * @param iSpeed   airspeed index
+    * @param iMTime   mission time index
+    * @param iGroll   ground roll index
+    * @param iVspeed  vertical speed index
+    * @param iBank    roll (bank) angle index
+    * @param iEng     engine setting index
+    * @param iHead    magnetic heading index
+    */
+   public DataIndex(int iSysTime, int iAlt, int iDme, int iHdef, int iVdef, int iASpeed, int iMTime, int iGroll,
+         int iVspeed, int iBank, int iEng, int iHead, int iLongitude, int iLatitude) {
+      this.iSysTime = iSysTime;
+      this.iAlt = iAlt;
+      this.iDme = iDme;
+      this.iHdef = iHdef;
+      this.iVdef = iVdef;
+      this.iASpeed = iASpeed;
+      this.iMTime = iMTime;
+      this.iGroll = iGroll;
+      this.iVspeed = iVspeed;
+      this.iBank = iBank;
+      this.iEng = iEng;
+      this.iHead = iHead;
+      this.iLongitude = iLongitude;
+      this.iLatitude = iLatitude;
+   }
+
+   public int getiLongitude() {
+      return iLongitude;
+   }
+
+   public void setiLongitude(int iLongitude) {
+      this.iLongitude = iLongitude;
+   }
+
+   public int getiLatitude() {
+      return iLatitude;
+   }
+
+   public void setiLatitude(int iLatitude) {
+      this.iLatitude = iLatitude;
+   }
+
+   public int getiSysTime() {
+      return iSysTime;
+   }
+
+   public void setiSysTime(int iSysTime) {
+      this.iSysTime = iSysTime;
+   }
+
+   public int getiAlt() {
+      return iAlt;
+   }
+
+   public void setiAlt(int iAlt) {
+      this.iAlt = iAlt;
+   }
+
+   public int getiDme() {
+      return iDme;
+   }
+
+   public void setiDme(int iDme) {
+      this.iDme = iDme;
+   }
+
+   public int getiHdef() {
+      return iHdef;
+   }
+
+   public void setiHdef(int iHdef) {
+      this.iHdef = iHdef;
+   }
+
+   public int getiVdef() {
+      return iVdef;
+   }
+
+   public void setiVdef(int iVdef) {
+      this.iVdef = iVdef;
+   }
+
+   public int getiASpeed() {
+      return iASpeed;
+   }
+
+   public void setiASpeed(int iSpeed) {
+      this.iASpeed = iSpeed;
+   }
+
+   public int getiMTime() {
+      return iMTime;
+   }
+
+   public void setiMTime(int iMTime) {
+      this.iMTime = iMTime;
+   }
+
+   public int getiGroll() {
+      return iGroll;
+   }
+
+   public void setiGroll(int iGroll) {
+      this.iGroll = iGroll;
+   }
+
+   public int getiVspeed() {
+      return iVspeed;
+   }
+
+   public void setiVspeed(int iVspeed) {
+      this.iVspeed = iVspeed;
+   }
+
+   public int getiBank() {
+      return iBank;
+   }
+
+   public void setiBank(int iBank) {
+      this.iBank = iBank;
+   }
+
+   public int getiEng() {
+      return iEng;
+   }
+
+   public void setiEng(int iEng) {
+      this.iEng = iEng;
+   }
+
+   public int getiHead() {
+      return iHead;
+   }
+
+   public void setiHead(int iHead) {
+      this.iHead = iHead;
+   }
+
+}

--- a/src/scoring/FlightData.java
+++ b/src/scoring/FlightData.java
@@ -1,10 +1,10 @@
 package scoring;
 
 import java.time.LocalDateTime;
-import java.util.LinkedList;
 import java.util.List;
 
 public class FlightData {
+
    // important timestamps
    private LocalDateTime beginFlightTimestamp = null;
    private LocalDateTime beginApproachTimestamp = null;
@@ -13,101 +13,28 @@ public class FlightData {
    private LocalDateTime endFlightTimestamp = null;
 
    // Stepdown portion
-   private List<Double> altStepdown;
-   private List<Double> dmeStepdown;
-   private List<Double> speedStepdown;
-   private List<Double> hDefStepdown;
-   private List<Double> rollBankStepdown;
-   private List<Double> verticalSpeedStepdown;
+   private List<FlightDataPoint> stepdownData;
    
    // Final Approach portion
-   private List<Double> vDefFinalApproach;
-   private List<Double> speedFinalApproach;
-   private List<Double> hDefFinalApproach;
-   private List<Double> verticalSpeedFinalApp;
-   private List<Double> rollBankFinalApp;
+   private List<FlightDataPoint> approachData;
+
    // Roundout portion
-   private List<Double> altRoundout;
-   private List<Double> hDefRoundout;
-   private List<Double> rollBankRoundout;
-   private List<Double> verticalSpeedRoundout;
+   private List<FlightDataPoint> roundoutData;
+
    // Landing portion
-   private List<Double> altLanding;
-   private List<Double> hDefLanding;
+   private List<FlightDataPoint> landingData;
+
    // Time data
    private double timeApproach = 0;
    private double timeLanding = 0;
    private double timeTotal = 0;
 
-   FlightData() {
-      // implemented as LinkedList because insertion at end is O(1)
-      // ArrayLists were not used intentionally!!!
-      this.altStepdown = new LinkedList<>();
-      this.dmeStepdown = new LinkedList<>();
-      this.speedStepdown = new LinkedList<>();
-      this.hDefStepdown = new LinkedList<>();
-      this.vDefFinalApproach = new LinkedList<>();
-      this.speedFinalApproach = new LinkedList<>();
-      this.hDefFinalApproach = new LinkedList<>();
-      this.verticalSpeedFinalApp = new LinkedList<>();
-      this.verticalSpeedStepdown = new LinkedList<>();
-      this.verticalSpeedRoundout = new LinkedList<>();
-      this.altRoundout = new LinkedList<>();
-      this.hDefRoundout = new LinkedList<>();
-      this.altLanding = new LinkedList<>();
-      this.hDefLanding = new LinkedList<>();
-      this.rollBankStepdown = new LinkedList<>();
-      this.rollBankFinalApp = new LinkedList<>();
-      this.rollBankRoundout = new LinkedList<>();
-   }
-
-   /**
-    * Constructor for when using Data.txt created by xplane software.
-    * @param altStepdown
-    * @param dmeStepdown
-    * @param speedStepdown
-    * @param hDefStepdown
-    * @param vDefFinalApproach
-    * @param speedFinalApproach
-    * @param hDefFinalApproach
-    * @param altRoundout
-    * @param hDefRoundout
-    * @param altLanding
-    * @param hDefLanding
-    * @param verticalSpeedFinalApp
-    * @param verticalSpeedStepdown
-    * @param verticalSpeedRoundout
-    * @param rollBankStepdown
-    * @param rollBankFinalApp
-    * @param rollBankRoundout
-    * @param timeApproach
-    * @param timeLanding
-    * @param timeTotal
-    */
-   public FlightData(List<Double> altStepdown, List<Double> dmeStepdown, List<Double> speedStepdown,
-         List<Double> hDefStepdown, List<Double> vDefFinalApproach, List<Double> speedFinalApproach,
-         List<Double> hDefFinalApproach, List<Double> altRoundout, List<Double> hDefRoundout, 
-         List<Double> altLanding, List<Double> hDefLanding, List<Double> verticalSpeedFinalApp,
-         List<Double> verticalSpeedStepdown, List<Double> verticalSpeedRoundout, List<Double> rollBankStepdown,
-         List<Double> rollBankFinalApp, List<Double> rollBankRoundout,
-         double timeApproach, double timeLanding, double timeTotal) {
-      this.altStepdown = altStepdown;
-      this.dmeStepdown = dmeStepdown;
-      this.speedStepdown = speedStepdown;
-      this.hDefStepdown = hDefStepdown;
-      this.vDefFinalApproach = vDefFinalApproach;
-      this.speedFinalApproach = speedFinalApproach;
-      this.hDefFinalApproach = hDefFinalApproach;
-      this.altRoundout = altRoundout;
-      this.hDefRoundout = hDefRoundout;
-      this.altLanding = altLanding;
-      this.hDefLanding = hDefLanding;
-      this.verticalSpeedFinalApp = verticalSpeedFinalApp;
-      this.verticalSpeedStepdown = verticalSpeedStepdown;
-      this.verticalSpeedRoundout = verticalSpeedRoundout;
-      this.rollBankStepdown = rollBankStepdown;
-      this.rollBankFinalApp = rollBankFinalApp;
-      this.rollBankRoundout = rollBankRoundout;
+   public FlightData(List<FlightDataPoint> stepdown, List<FlightDataPoint> approach, List<FlightDataPoint> roundout,
+         List<FlightDataPoint> landing, double timeApproach, double timeLanding, double timeTotal) {
+      this.stepdownData = stepdown;
+      this.approachData = approach;
+      this.roundoutData = roundout;
+      this.landingData = landing;
       this.timeApproach = timeApproach;
       this.timeLanding = timeLanding;
       this.timeTotal = timeTotal;
@@ -115,39 +42,56 @@ public class FlightData {
 
    public FlightData(LocalDateTime beginFlightTimestamp, LocalDateTime beginApproachTimestamp,
          LocalDateTime beginRoundOutTimestamp, LocalDateTime beginLandingTimestamp, LocalDateTime endFlightTimestamp,
-         List<Double> altStepdown, List<Double> dmeStepdown, List<Double> speedStepdown,
-         List<Double> hDefStepdown, List<Double> vDefFinalApproach, List<Double> speedFinalApproach,
-         List<Double> hDefFinalApproach, List<Double> altRoundout, List<Double> hDefRoundout, 
-         List<Double> altLanding, List<Double> hDefLanding, List<Double> verticalSpeedFinalApp,
-         List<Double> verticalSpeedStepdown, List<Double> verticalSpeedRoundout, List<Double> rollBankStepdown,
-         List<Double> rollBankFinalApp, List<Double> rollBankRoundout,
-         double timeApproach, double timeLanding, double timeTotal) {
-      
+         List<FlightDataPoint> stepdown, List<FlightDataPoint> approach, List<FlightDataPoint> roundout,
+         List<FlightDataPoint> landing, double timeApproach, double timeLanding, double timeTotal) {
       this.beginFlightTimestamp = beginFlightTimestamp;
       this.beginApproachTimestamp = beginApproachTimestamp;
       this.beginRoundOutTimestamp = beginRoundOutTimestamp;
       this.beginLandingTimestamp = beginLandingTimestamp;
       this.endFlightTimestamp = endFlightTimestamp;
-      this.altStepdown = altStepdown;
-      this.dmeStepdown = dmeStepdown;
-      this.speedStepdown = speedStepdown;
-      this.hDefStepdown = hDefStepdown;
-      this.vDefFinalApproach = vDefFinalApproach;
-      this.speedFinalApproach = speedFinalApproach;
-      this.hDefFinalApproach = hDefFinalApproach;
-      this.altRoundout = altRoundout;
-      this.hDefRoundout = hDefRoundout;
-      this.altLanding = altLanding;
-      this.hDefLanding = hDefLanding;
-      this.verticalSpeedFinalApp = verticalSpeedFinalApp;
-      this.verticalSpeedStepdown = verticalSpeedStepdown;
-      this.verticalSpeedRoundout = verticalSpeedRoundout;
-      this.rollBankStepdown = rollBankStepdown;
-      this.rollBankFinalApp = rollBankFinalApp;
-      this.rollBankRoundout = rollBankRoundout;
+      this.stepdownData = stepdown;
+      this.approachData = approach;
+      this.roundoutData = roundout;
+      this.landingData = landing;
       this.timeApproach = timeApproach;
       this.timeLanding = timeLanding;
       this.timeTotal = timeTotal;
+   }
+
+   public void setBeginFlightTimestamp(LocalDateTime beginFlightTimestamp) {
+      this.beginFlightTimestamp = beginFlightTimestamp;
+   }
+
+   public void setBeginApproachTimestamp(LocalDateTime beginApproachTimestamp) {
+      this.beginApproachTimestamp = beginApproachTimestamp;
+   }
+
+   public void setBeginRoundOutTimestamp(LocalDateTime beginRoundOutTimestamp) {
+      this.beginRoundOutTimestamp = beginRoundOutTimestamp;
+   }
+
+   public void setBeginLandingTimestamp(LocalDateTime beginLandingTimestamp) {
+      this.beginLandingTimestamp = beginLandingTimestamp;
+   }
+
+   public void setEndFlightTimestamp(LocalDateTime endFlightTimestamp) {
+      this.endFlightTimestamp = endFlightTimestamp;
+   }
+
+   public List<FlightDataPoint> getStepdownData() {
+      return stepdownData;
+   }
+
+   public List<FlightDataPoint> getApproachData() {
+      return approachData;
+   }
+
+   public List<FlightDataPoint> getRoundoutData() {
+      return roundoutData;
+   }
+
+   public List<FlightDataPoint> getLandingData() {
+      return landingData;
    }
 
    public LocalDateTime getBeginFlightTimestamp() {
@@ -168,95 +112,6 @@ public class FlightData {
 
    public LocalDateTime getEndFlightTimestamp() {
       return endFlightTimestamp;
-   }
-
-   public List<Double> getAltStepdown() {
-      return this.altStepdown;
-   }
-
-   public List<Double> getDmeStepdown() {
-      return dmeStepdown;
-   }
-
-   public void setDmeStepdown(List<Double> dmeStepdown) {
-      this.dmeStepdown = dmeStepdown;
-   }
-
-   public List<Double> getSpeedStepdown() {
-      return speedStepdown;
-   }
-
-   public List<Double> getHDefStepdown() {
-      return hDefStepdown;
-   }
-
-   public List<Double> getVDefFinalApproach() {
-      return vDefFinalApproach;
-   }
-
-   public List<Double> getSpeedFinalApproach() {
-      return speedFinalApproach;
-   }
-
-   public List<Double> getHDefFinalApproach() {
-      return hDefFinalApproach;
-   }
-
-   public List<Double> getAltRoundout() {
-      return altRoundout;
-   }
-
-   public List<Double> getHDefRoundout() {
-	   return hDefRoundout;
-   }
-
-   public List<Double> getAltLanding() {
-      return altLanding;
-   }
-
-   public List<Double> getHDefLanding() {
-      return hDefLanding;
-   }
-
-   public List<Double> getVerticalSpeedFinalApp() {
-	  return verticalSpeedFinalApp;
-   }
-
-   public List<Double> getVerticalSpeedStepdown() {
-	   return verticalSpeedStepdown;
-   }
-
-   public List<Double> getVerticalSpeedRoundout() {
-	   return verticalSpeedRoundout;
-   }
-
-   public List<Double> getRollBankStepdown() {
-	   return rollBankStepdown;
-   }
-
-   public List<Double> getRollFinalApp() {
-	   return rollBankFinalApp;
-   }
-
-   public List<Double> getRollBankRoundout() {
-	   return rollBankRoundout;
-   }
-
-   // Returning portions of the approach and landing
-   public List<Double> gethDefStepdown() {
-      return hDefStepdown;
-   }
-
-   public List<Double> getvDefFinalApproach() {
-      return vDefFinalApproach;
-   }
-
-   public List<Double> gethDefFinalApproach() {
-      return hDefFinalApproach;
-   }
-
-   public List<Double> gethDefLanding() {
-      return hDefLanding;
    }
 
    public double getTimeApproach() {

--- a/src/scoring/FlightDataPoint.java
+++ b/src/scoring/FlightDataPoint.java
@@ -1,0 +1,109 @@
+package scoring;
+
+/**
+ * Holds data for a single flight data point/entry.
+ */
+public class FlightDataPoint {
+
+   private double missn_time = 0;
+   private double airspeed = 0;
+   private double engine = 0;
+   private double bank = 0;
+   private double groll = 0;
+   private double heading = 0;
+   private double vertSpeed = 0;
+   private double altitude = 0;
+   private double latitude = 0;
+   private double longitude = 0;
+   private double dme = 0;
+   private double hdef = 0;
+   private double vdef = 0;
+
+   /**
+    * Constructor.
+    * 
+    * @param missn_time mission time
+    * @param airspeed   airspeed
+    * @param engine     engine speed
+    * @param bank       Roll (bank) angle
+    * @param groll      Landing distance "ground roll"
+    * @param vvi        vertical speed
+    * @param altitude   altitude
+    * @param heading    magnetic heading
+    * @param latitude   latitude
+    * @param longitude  longitude
+    * @param dme        DME distance
+    * @param hdef       localizer deflection
+    * @param vdef       glideslope deflection
+    */
+   public FlightDataPoint(double missn_time, double airspeed, double engine, double bank, double groll,
+         double vvi, double altitude, double heading, double latitude, double longitude,
+         double dme, double hdef, double vdef) {
+      this.missn_time = missn_time;
+      this.airspeed = airspeed;
+      this.engine = engine;
+      this.bank = bank;
+      this.groll = groll;
+      this.vertSpeed = vvi;
+      this.altitude = altitude;
+      this.heading = heading;
+      this.latitude = latitude;
+      this.longitude = longitude;
+      this.dme = dme;
+      this.hdef = hdef;
+      this.vdef = vdef;
+   };
+
+   public double getMissn_time() {
+      return missn_time;
+   }
+
+   public double getAirspeed() {
+      return airspeed;
+   }
+
+   public double getEngine() {
+      return engine;
+   }
+
+   public double getBank() {
+      return bank;
+   }
+
+   public double getGroll() {
+      return groll;
+   }
+
+   public double getVertSpeed() {
+      return vertSpeed;
+   }
+
+   public double getAltitude() {
+      return altitude;
+   }
+
+   public double getHeading() {
+      return heading;
+   }
+
+   public double getLatitude() {
+      return latitude;
+   }
+
+   public double getLongitude() {
+      return longitude;
+   }
+
+   public double getDme() {
+      return dme;
+   }
+
+   public double getHdef() {
+      return hdef;
+   }
+
+   public double getVdef() {
+      return vdef;
+   }
+
+}

--- a/src/scoring/ScoreRunner.java
+++ b/src/scoring/ScoreRunner.java
@@ -62,7 +62,7 @@ public class ScoreRunner {
 
 			//initializes the start and stop time for the ILS, Roundout, and landing phase
 
-		} else if (!xplaneExtension.equals("csv")) {
+		} else {
 			System.out.println("Xplane data is not in a supported file type");
 			return;
 		}


### PR DESCRIPTION
- Flight data is now held in a list of FlightDataPoint objects rather than multiple lists that only contain one type of flight data values. 
  - This will make it easier to do longitude and latitude tests in the future.
  - Also, it makes the argument list on methods much smaller.
- The ScoreRunner now only accepts the xplane.txt file as flight data input because we intend to utilize values we did not collect in the datarefs.csv.
  - The datarefs.csv file is still necessary for trimming gaze data but that has not been fixed at this time.

Fixes #9 