### PR TITLE
Scoring improvements

### DIFF
--- a/src/scoring/Parser.java
+++ b/src/scoring/Parser.java
@@ -155,7 +155,7 @@ public class Parser {
 		ScoreCalculation score;
 		String basePathName = outputFolderPath + "//" + name + "_flight_data";
 		String stepdownOutputFilePath = basePathName + "_stepdown.csv";
-		String finalApproachOutputFilePath = basePathName + "_approach.csv";
+		String finalApproachOutputFilePath = basePathName + "_finalapproach.csv";
 		String roundOutOutputFilePath = basePathName + "_roundout.csv";
 		String landingOutputFilePath = basePathName+ "_landing.csv";
 

--- a/src/scoring/ScoreCalculation.java
+++ b/src/scoring/ScoreCalculation.java
@@ -183,14 +183,16 @@ public class ScoreCalculation {
 		double absValueVDef = Math.abs(vdef);
 		glideslopeAddedTotal += absValueVDef;
 
-		if (vspeed > -1000)	// if descending at rate greater than 1000 ft/min, unstable
+		// if descending at rate greater than 1000 ft/min, unstable
+		// if vdef == -0.0, no points
+		if (vspeed < -1000 || (vdef == 0 && 1/vdef < 0))	
 		{
+			penalty = -1;
+		}
+		else {
 			if(absValueVDef  < 2.5) {
 				penalty += absValueVDef / 2.5;
 			} 
-		}
-		else {
-			penalty += 1;
 		}
 		
 		return penalty;
@@ -259,11 +261,14 @@ public class ScoreCalculation {
 		double penalty = 0;
 
 		for (FlightDataPoint point : this.data.getStepdownData()) {
-			penalty += localizerScorePenalty(point.getHdef(), point.getBank()) 
-				+ speedILSCalcPenalty(point.getAirspeed())
-				+ altitudeILSCalcPenalty(point.getDme(), point.getAltitude(), point.getVertSpeed());
+			if (point.getHdef() == 0.0 && 1/point.getHdef() < 0) {	// equals -0.0
+				penalty += 3;
+			} else {
+				penalty += localizerScorePenalty(point.getHdef(), point.getBank()) 
+					+ speedILSCalcPenalty(point.getAirspeed())
+					+ altitudeILSCalcPenalty(point.getDme(), point.getAltitude(), point.getVertSpeed());
+			}
 		}
-
 		return penalty;
 	}
 
@@ -274,9 +279,13 @@ public class ScoreCalculation {
 	public double scoreFinalApproachCalc() {	
 		double penalty = 0;
 		for (FlightDataPoint point : this.data.getApproachData()) {
-			penalty += localizerScorePenalty(point.getHdef(), point.getBank())
-			+ speedILSCalcPenalty(point.getAirspeed())
-			+ glideSlopeScorePenalty(point.getVdef(), point.getVertSpeed());
+			if (point.getHdef() == 0.0 && 1/point.getHdef() < 0) {	// equals -0.0
+				penalty += 3;
+			} else {
+				penalty += localizerScorePenalty(point.getHdef(), point.getBank())
+				+ speedILSCalcPenalty(point.getAirspeed())
+				+ glideSlopeScorePenalty(point.getVdef(), point.getVertSpeed());
+			}
 		}
 		return penalty;
 	}
@@ -290,8 +299,12 @@ public class ScoreCalculation {
 		double penalty = 0;
 
 		for (FlightDataPoint point : this.data.getRoundoutData()) {
-			penalty += scoreVerticalSpeed(point.getVertSpeed());
-			localizerScorePenalty(point.getHdef(), point.getBank());
+			if (point.getHdef() == 0.0 && 1/point.getHdef() < 0) {	// equals -0
+				penalty += 3;
+			} else {
+				penalty += scoreVerticalSpeed(point.getVertSpeed())
+					+ localizerScorePenalty(point.getHdef(), point.getBank());
+			}
 		}
 
 		return penalty;

--- a/src/scoring/ScoreCalculation.java
+++ b/src/scoring/ScoreCalculation.java
@@ -187,7 +187,7 @@ public class ScoreCalculation {
 		// if vdef == -0.0, no points
 		if (vspeed < -1000 || (vdef == 0 && 1/vdef < 0))	
 		{
-			penalty = -1;
+			penalty = 1;
 		}
 		else {
 			if(absValueVDef  < 2.5) {

--- a/src/scoring/ScoreCalculation.java
+++ b/src/scoring/ScoreCalculation.java
@@ -21,6 +21,7 @@ public class ScoreCalculation {
 	private final static int MAX_PTS_PER_DATA_POINT_ROUNDOUT = 2; 
 	private final static int MAX_PTS_PER_DATA_POINT_LANDING = 2;
 	private final static int TARGET_SPEED = 90;
+	private final static int TARGET_HEADING = 344;
 
 	private String participant;
 
@@ -130,21 +131,22 @@ public class ScoreCalculation {
 	 * @param hdef is all of the localizer position of the aircraft in dots
 	 * @return returns the penalty
 	 */
-	private double localizerScorePenalty(double hdef, double bankAngle) {
+	private double localizerScorePenalty(double hdef, double bankAngle, double heading) {
 		double penalty = 0;
-		double absValueLoc = Math.abs(hdef);
-		double absValueBank = Math.abs(bankAngle);
+		double absHdef = Math.abs(hdef);
+		double absBankAngle = Math.abs(bankAngle);
+		double headingDiff = Math.abs(TARGET_HEADING - heading);
 
-		localizerAddedTotal += absValueLoc;
-		bankAngleAddedTotal += absValueBank;
+		localizerAddedTotal += absHdef;
+		bankAngleAddedTotal += absBankAngle;
 		
-		if (absValueBank > Math.abs(this.maxBankAngle))
+		if (absBankAngle > Math.abs(this.maxBankAngle))
 		{
-			this.maxBankAngle = absValueBank;
+			this.maxBankAngle = absBankAngle;
 		}
 		
-		if (absValueBank < 15 && absValueLoc < 2.5) {
-			penalty = absValueLoc / 2.5;	
+		if (absBankAngle < 15 && absHdef < 2.5 && headingDiff <= 25) {
+			penalty = absHdef / 2.5;	
 		} else {
 			penalty = 1;
 		}
@@ -159,11 +161,11 @@ public class ScoreCalculation {
 	 */
 	private double localizerScorePenaltyLanding(double hdef) {
 		double penalty = 0;
-		double absValueHdef = Math.abs(hdef);
-		localizerAddedTotal += absValueHdef;	
+		double absHdef = Math.abs(hdef);
+		localizerAddedTotal += absHdef;	
 
-		if(absValueHdef  < 2.5) {
-			penalty = absValueHdef / 2.5;
+		if(absHdef  < 2.5) {
+			penalty = absHdef / 2.5;
 		} else {
 			penalty = 1;
 		}
@@ -180,8 +182,8 @@ public class ScoreCalculation {
 		double penalty = 0;
 		verticalSpeedAddedTotal += vspeed;
 		
-		double absValueVDef = Math.abs(vdef);
-		glideslopeAddedTotal += absValueVDef;
+		double absVdef = Math.abs(vdef);
+		glideslopeAddedTotal += absVdef;
 
 		// if descending at rate greater than 1000 ft/min, unstable
 		// if vdef == -0.0, no points
@@ -190,8 +192,8 @@ public class ScoreCalculation {
 			penalty = 1;
 		}
 		else {
-			if(absValueVDef  < 2.5) {
-				penalty += absValueVDef / 2.5;
+			if(absVdef  < 2.5) {
+				penalty += absVdef / 2.5;
 			} 
 		}
 		
@@ -264,7 +266,7 @@ public class ScoreCalculation {
 			if (point.getHdef() == 0.0 && 1/point.getHdef() < 0) {	// equals -0.0
 				penalty += 3;
 			} else {
-				penalty += localizerScorePenalty(point.getHdef(), point.getBank()) 
+				penalty += localizerScorePenalty(point.getHdef(), point.getBank(), point.getHeading()) 
 					+ speedILSCalcPenalty(point.getAirspeed())
 					+ altitudeILSCalcPenalty(point.getDme(), point.getAltitude(), point.getVertSpeed());
 			}
@@ -282,7 +284,7 @@ public class ScoreCalculation {
 			if (point.getHdef() == 0.0 && 1/point.getHdef() < 0) {	// equals -0.0
 				penalty += 3;
 			} else {
-				penalty += localizerScorePenalty(point.getHdef(), point.getBank())
+				penalty += localizerScorePenalty(point.getHdef(), point.getBank(), point.getHeading())
 				+ speedILSCalcPenalty(point.getAirspeed())
 				+ glideSlopeScorePenalty(point.getVdef(), point.getVertSpeed());
 			}
@@ -303,7 +305,7 @@ public class ScoreCalculation {
 				penalty += 3;
 			} else {
 				penalty += scoreVerticalSpeed(point.getVertSpeed())
-					+ localizerScorePenalty(point.getHdef(), point.getBank());
+					+ localizerScorePenalty(point.getHdef(), point.getBank(), point.getHeading());
 			}
 		}
 

--- a/src/scoring/ScoreRunner.java
+++ b/src/scoring/ScoreRunner.java
@@ -18,8 +18,10 @@ public class ScoreRunner {
 
 	/**
 	 * entry point of scoring calculation program
-	 * @param args[1] output directory path
+	 * @param args[0] output directory path
 	 * @param args[1] xplane data file path
+	 * @param args[2] csv file with timestamps and dme
+	 * @param args[3..n] gaze files to trim
 	 */
 	public static void main(String[] args) {
 
@@ -75,6 +77,10 @@ public class ScoreRunner {
 
 		FlightData flightData = score.getFlightData();
 		// trim gaze files
+
+		if (args.length < 3) {
+			return;
+		} 
 	
 		Parser.setTimestamps(args[2], flightData);
 


### PR DESCRIPTION
Fixes #12 and Fixes #13 

## Implemented heading check:
- Pilot with abs(344 - heading) > 25 will receive a penalty of 1 for their localizer score during the Stepdown and Final Approach phases.

## Fix accumulators for average/max values:
- data points outside localizer signal (hdef = -0.0) are now counted by accumulators.
- additional measures only include data points from Stepdown and Final Approach phases 
  - The focus of our study is the ILS approach score, not landing. I can add additional descriptive measures for the landing in the future if we decide to it is needed